### PR TITLE
update m3u8_pull_url when creating push_url

### DIFF
--- a/app/controllers/api/v1/avl/push_stream_info_controller.rb
+++ b/app/controllers/api/v1/avl/push_stream_info_controller.rb
@@ -4,11 +4,31 @@ class Api::V1::Avl::PushStreamInfoController < Api::BaseController
   include Avl::AvlStreamInfoHelper
 
   before_action :require_user!
+  before_action :set_firebase
 
   def show
-    pushUrl =  generateRtcPushStreamUrl params[:id]
+    roomId = params[:id]
+    pushUrl =  generateRtcPushStreamUrl roomId
+    m3u8_pull_url = generateM3u8PullStreamUrl roomId
+    room = {
+      :m3u8_pull_url => m3u8_pull_url,
+    }
+    response = @firebase.update("room/#{roomId}", room)
+
     @streamInfo = Avl::AvlPushStreamInfo.new
     @streamInfo.push_stream_url = pushUrl
+    @streamInfo.m3u8_pull_url = m3u8_pull_url
     render json: @streamInfo
   end
+
+  private
+
+  def set_firebase
+    # private_key_json_string = File.open(ENV['GOOGLE_APPLICATION_CREDENTIALS']).read
+    # @firebase = Firebase::Client.new(ENV['FIREBASE_DATABASEURL'], private_key_json_string)
+    puts "#{ENV['FIREBASE_DATABASEURL']}, #{ENV['FIREBASE_DATABASE_SECRET']}"
+    @firebase = Firebase::Client.new(ENV['FIREBASE_DATABASEURL'], ENV['FIREBASE_DATABASE_SECRET'])
+    @firebase.request.connect_timeout = 10
+  end
+
 end

--- a/app/controllers/api/v1/livechat_controller.rb
+++ b/app/controllers/api/v1/livechat_controller.rb
@@ -22,11 +22,7 @@ class Api::V1::LivechatController < Api::BaseController
     response = @firebase.push('room', room)
     if response.code == 200
       roomId = response.body['name']
-      room['key'] = roomId
-      room['stream_name'] = generateStreamName roomId
-      room['m3u8_pull_url'] = generateM3u8PullStreamUrl roomId
-      room['rtmp_pull_url'] = generateRtmpPullStreamUrl roomId
-      response = @firebase.update("room/#{roomId}", room)
+      room[:key] = roomId
     end
     render json: room, status: response.code
   end
@@ -182,6 +178,7 @@ class Api::V1::LivechatController < Api::BaseController
     if response.code == 200
       if response.body.values.length > 0
         room = response.body.values[0]
+        room[:key] = response.body.keys[0]
         render json: room, status: response.code
       else
         render json: { error: 'no room' }, status: 404

--- a/app/models/avl/avl_push_stream_info.rb
+++ b/app/models/avl/avl_push_stream_info.rb
@@ -4,4 +4,5 @@ class Avl::AvlPushStreamInfo
   include ActiveModel::Model
 
   attr_accessor :push_stream_url
+  attr_accessor :m3u8_pull_url
 end


### PR DESCRIPTION
iPhoneアプリから配信開始時に、視聴用URLを更新
iPhoneアプリから配信用の画面でhlsの再生を失敗しにくくした
hlsプレイヤーだけ再読み込みするボタン追加